### PR TITLE
Fixes Ember.run.debounce use in search method for politicians, questions, and questions asked by a politician

### DIFF
--- a/app/controllers/politician.js
+++ b/app/controllers/politician.js
@@ -7,11 +7,12 @@ export default Ember.ObjectController.extend(InfiniteScrollControllerMixin, {
   isSearching: false,
 
   searchQueryObserver: function () {
-    var query = this.get('searchQuery').split(' ').join('+');
-    Ember.run.debounce(this, this.execQuery(query), 600);
+    Ember.run.debounce(this, this.execQuery, 600);
   }.observes('searchQuery'),
 
-  execQuery: function (query) {
+  execQuery: function () {
+    var query = this.get('searchQuery').split(' ').join('+');
+    
     var limit = 20,
         politician_id = this.get('model').get('id'),
         params;

--- a/app/controllers/politicians.js
+++ b/app/controllers/politicians.js
@@ -5,12 +5,12 @@ export default Ember.ArrayController.extend({
   isSearching: false,
 
   searchQueryObserver: function () {
-    var query = this.get('searchQuery').toLowerCase();
-    Ember.run.debounce(this, this.updateContent(query), 600);
+    Ember.run.debounce(this, this.updateContent, 600);
   }.observes('searchQuery'),
 
-  updateContent: function (query) {
+  updateContent: function () {
     var that = this;
+    var query = this.get('searchQuery').toLowerCase();
     var regexp = new RegExp(query);
 
     that.clearResults();

--- a/app/controllers/questions.js
+++ b/app/controllers/questions.js
@@ -13,11 +13,12 @@ export default Ember.ArrayController.extend(InfiniteScrollControllerMixin, {
   model : [],
 
   searchQueryObserver: function () {
-    var query = this.get('searchQuery').split(' ').join('+');
-    Ember.run.debounce(this, this.execQuery(query), 600);
+    Ember.run.debounce(this, this.execQuery, 600);
   }.observes('searchQuery'),
 
-  execQuery: function (query) {
+  execQuery: function () {
+    var query = this.get('searchQuery').split(' ').join('+');
+
     var limit = 20,
         params;
 


### PR DESCRIPTION
Very partly fixes #51 (the patch makes the search faster in the sense of more responsive)

The lagging problems partly come from a misuse of `Ember.run.debounce`.
The second argument to `debounce()` should be a method, like `this.execQuery`, and not the result of calling a method, like `this.execQuery(query)`. (In the latter case, `execQuery` is executed directly each time a key is pressed, and the "method" `null` is delayed to 600ms later...)
See http://emberjs.com/api/classes/Ember.run.html#method_debounce .
